### PR TITLE
Small fix for a glue test:

### DIFF
--- a/aviary/docs/user_guide/postprocessing_and_visualizing_results.ipynb
+++ b/aviary/docs/user_guide/postprocessing_and_visualizing_results.ipynb
@@ -316,14 +316,19 @@
     "\n",
     "run_and_check(av.Verbosity.QUIET)\n",
     "run_and_check(av.Verbosity.BRIEF)\n",
-    "run_and_check(av.Verbosity.VERBOSE)\n",
     "try:\n",
-    "    run_and_check(av.Verbosity.DEBUG,optimizer='SNOPT')\n",
+    "    run_and_check(av.Verbosity.VERBOSE,optimizer='SNOPT')\n",
     "except ImportError:\n",
     "    pass # SNOPT might not be available\n",
-    "run_and_check(av.Verbosity.DEBUG,optimizer='IPOPT')\n",
-    "run_and_check(av.Verbosity.DEBUG,optimizer='SLSQP')\n",
-    "\n"
+    "try:\n",
+    "    run_and_check(av.Verbosity.VERBOSE,optimizer='IPOPT')\n",
+    "except ImportError:\n",
+    "    pass # SNOPT might not be available\n",
+    "\n",
+    "run_and_check(av.Verbosity.VERBOSE,optimizer='SLSQP')\n",
+    "\n",
+    "# NOTE: We can't test with verbosity=DEBUG here because `show_sparsity=True` in the driver coloring generates a Bokeh report, \n",
+    "# and there seem to be some unexpected interactions inside of a notebook cell. This might be fixable on the OpenMDAO side.\n"
    ]
   },
   {
@@ -384,7 +389,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "av1",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -398,9 +403,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
OpenMDAO sparsity graphic display doesn't work well in a cell

### Summary

This is a fix for a glue test failure on a PR that activates the OpenMDAO coloring sparsity graph when verbosity is DEBUG.  The sparsity graph is in Bokeh, and doesn't seem to work in a notebook cell. This can possibly be fixed on the openmdao side, but for now, we can perform this glue test just as well on the next lower verbosity scale VERBOSE.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None